### PR TITLE
Support custom formatting function for errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,31 @@ var error = require('koa-json-error')
 app.use(error())
 ```
 
+### Advanced usage
+You may pass in an `options` object as argument to the middleware. These are the available settings.
+
+#### `options.format(Function)`
+If you don't really feel that showing the stack trace is _that_ cool, you can customize the way errors are shown on responses through a formatter function. It receives the raw error object and it is expected to return the formatted response.
+
+```js
+'use strict';
+var koa = require('koa');
+var error = require('koa-json-error');
+
+var options = {
+  format: function(err) {
+    return {
+      status: 200,
+      message: err.message || 'OK';
+    }
+  }
+}
+var app = koa();
+app.use(error(options));
+```
+
+> Modifying the error inside the `format` function will mutate the original object.
+
 [npm-image]: https://img.shields.io/npm/v/koa-json-error.svg?style=flat-square
 [npm-url]: https://npmjs.org/package/koa-json-error
 [travis-image]: https://img.shields.io/travis/koajs/json-error/master.svg?style=flat-square

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 var defaults = require('lodash.defaults');
+var assign = require('lodash.assign');
 
 var props = [
   'name',
@@ -11,7 +12,7 @@ var props = [
 var DEFAULTS = {
   format: function(err) {
     // set all enumerable properties of error onto the object
-    var obj =  Object.assign({}, err)
+    var obj =  assign({}, err)
 
     props.forEach(function (key) {
       var value = err[key]

--- a/index.js
+++ b/index.js
@@ -10,12 +10,9 @@ var props = [
 
 var DEFAULTS = {
   format: function(err) {
-    var obj = {}
-
     // set all enumerable properties of error onto the object
-    Object.keys(err).forEach(function (key) {
-      obj[key] = err[key]
-    })
+    var obj =  Object.assign({}, err)
+
     props.forEach(function (key) {
       var value = err[key]
       if (value) obj[key] = value

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   },
   "files": [
     "index.js"
-  ]
+  ],
+  "dependencies": {
+    "lodash.defaults": "^4.0.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "index.js"
   ],
   "dependencies": {
+    "lodash.assign": "^4.0.7",
     "lodash.defaults": "^4.0.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -5,100 +5,144 @@ var koa = require('koa')
 
 var error = require('..')
 
-it('should show the stack', function (done) {
-  var app = koa()
-  app.use(error())
-  app.use(function* () {
-    throw new Error()
-  })
-  request(app.listen())
-  .get('/')
-  .expect(500, function (err, res) {
-    if (err) return done(err)
+describe('with default options', function () {
+  it('should show the stack', function (done) {
+    var app = koa()
+    app.use(error())
+    app.use(function* () {
+      throw new Error()
+    })
+    request(app.listen())
+    .get('/')
+    .expect(500, function (err, res) {
+      if (err) return done(err)
 
-    assert(res.body)
-    done()
+      assert(res.body)
+      done()
+    })
+  })
+
+  it('should show the name', function (done) {
+    var app = koa()
+    app.use(error())
+    app.use(function* () {
+      throw new Error()
+    })
+    request(app.listen())
+    .get('/')
+    .expect(500, function (err, res) {
+      if (err) return done(err)
+
+      assert.equal('Error', res.body.name)
+      done()
+    })
+  })
+
+  it('should show the message', function (done) {
+    var app = koa()
+    app.use(error())
+    app.use(function* () {
+      throw new Error('boom')
+    })
+    request(app.listen())
+    .get('/')
+    .expect(500, function (err, res) {
+      if (err) return done(err)
+
+      assert.equal('boom', res.body.message)
+      done()
+    })
+  })
+
+  it('should show the status', function (done) {
+    var app = koa()
+    app.use(error())
+    app.use(function* () {
+      this.throw(404)
+    })
+    request(app.listen())
+    .get('/')
+    .expect(404, function (err, res) {
+      if (err) return done(err)
+
+      assert.equal('Not Found', res.body.message)
+      assert.equal(404, res.body.status)
+      done()
+    })
+  })
+
+  it('should check for err.statusCode', function (done) {
+    var app = koa()
+    app.use(error())
+    app.use(function* () {
+      var err = new Error('boom')
+      err.statusCode = 501
+      throw err
+    })
+
+    request(app.listen())
+    .get('/')
+    .expect(501, done)
+  })
+
+  it('should emit errors', function (done) {
+    var app = koa()
+    app.use(error())
+    app.use(function* () {
+      throw new Error('boom')
+    })
+
+    app.once('error', function (err, ctx) {
+      assert.equal('boom', err.message)
+      assert.equal(500, ctx.status)
+      done()
+    })
+
+    request(app.listen())
+    .get('/')
+    .expect(500, function () {})
   })
 })
 
-it('should show the name', function (done) {
-  var app = koa()
-  app.use(error())
-  app.use(function* () {
-    throw new Error()
-  })
-  request(app.listen())
-  .get('/')
-  .expect(500, function (err, res) {
-    if (err) return done(err)
+describe('with custom format function', function() {
+  it('should allow defining a format function', function () {
+    var options = {
+      format: Function.prototype
+    }
 
-    assert.equal('Error', res.body.name)
-    done()
-  })
-})
-
-it('should show the message', function (done) {
-  var app = koa()
-  app.use(error())
-  app.use(function* () {
-    throw new Error('boom')
-  })
-  request(app.listen())
-  .get('/')
-  .expect(500, function (err, res) {
-    if (err) return done(err)
-
-    assert.equal('boom', res.body.message)
-    done()
-  })
-})
-
-it('should show the status', function (done) {
-  var app = koa()
-  app.use(error())
-  app.use(function* () {
-    this.throw(404)
-  })
-  request(app.listen())
-  .get('/')
-  .expect(404, function (err, res) {
-    if (err) return done(err)
-
-    assert.equal('Not Found', res.body.message)
-    assert.equal(404, res.body.status)
-    done()
-  })
-})
-
-it('should check for err.statusCode', function (done) {
-  var app = koa()
-  app.use(error())
-  app.use(function* () {
-    var err = new Error('boom')
-    err.statusCode = 501
-    throw err
+    var app = koa()
+    assert.doesNotThrow(function () {
+      app.use(error(options))
+    })
   })
 
-  request(app.listen())
-  .get('/')
-  .expect(501, done)
-})
+  it('should respect custom format while preserving status', function(done) {
+    var options = {
+      format: function(err) {
+        return {
+          status: 200,
+          message: 'OK'
+        }
+      }
+    }
 
-it('should emit errors', function (done) {
-  var app = koa()
-  app.use(error())
-  app.use(function* () {
-    throw new Error('boom')
+    var app = koa()
+    app.use(error(options))
+    app.use(function* () {
+      var err = new Error('boom')
+      err.statusCode = 501
+      err.customField = 'fatal'
+      throw err
+    })
+
+    request(app.listen())
+    .get('/')
+    .expect(501, function (err, res) {
+      if (err) return done(err)
+
+      assert.equal('OK', res.body.message)
+      assert.equal(200, res.body.status)
+      done()
+    })
   })
-
-  app.once('error', function (err) {
-    assert.equal('boom', err.message)
-    assert.equal(500, err.status)
-
-    done()
-  })
-
-  request(app.listen())
-  .get('/')
-  .expect(500, function () {})
 })


### PR DESCRIPTION
- Allow passing a `format` function to an `options` object to serialize errors.
- Unit tests.
- Expand documentation to showcase the feature.
