### PR TITLE
Fix the example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ const error = require('koa-json-error')
 
 let options = {
     // Avoid showing the stacktrace in 'production' env
-    postFormat: (e, obj) => process.env.NODE_ENV === 'production' : _.omit(obj, 'stack') : obj
+    postFormat: (e, obj) => process.env.NODE_ENV === 'production' ? _.omit(obj, 'stack') : obj
 };
 let app = new Koa();
 app.use(error(options));


### PR DESCRIPTION
incorrect ternary usage
